### PR TITLE
[FIX] Task 의존성 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
         }
     }
 
-    build {
+    bootJar {
         dependsOn(asciidoctor)
     }
 }


### PR DESCRIPTION
## build.gradle.kts task 의존성 변경

### 한줄 요약

gradle build 해야 asciidoctorTask가 실행되던것 gradle bootJar 로 의존성 변경

### 상세 설명

[6d792ddda1ce15b151624f7b4f4c1b2b7ca3e646]: gradle build -> gradle bootjar 로 asciidoctor 트리거

### TODO
