### PR TITLE
[FEAT] CI 설정

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -1,0 +1,30 @@
+name: GGZZ Gradle CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  continuous-integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        jdk-version: [ 17 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.jdk-version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk-version }}
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execution permission
+        run: chmod +x ./gradlew
+
+      - name: Run Tests
+        run: ./gradlew test --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar
 EXPOSE 8080
-CMD java -jar build/libs/ggzz-server.jar
+ENTRYPOINT ["java", "-jar", "build/libs/ggzz-server.jar"]
+CMD ["--spring.profiles.active=dev"]

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,21 @@
 spring:
   profiles:
-    active: dev
+    active: local
+
+---
+
+spring:
+  jpa:
+    open-in-view: false
+    generate-ddl: false
+    hibernate:
+      ddl-auto: validate
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 20MB
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 ---
 
@@ -24,33 +39,26 @@ server:
         same-site: none
         secure: true
 
-#springdoc:
-#  swagger-ui:
-#    enabled: false
-#  api-docs:
-#    enabled: false
-
 ---
 
-spring.config.activate.on-profile: dev
+spring:
+  config:
+    activate:
+      on-profile: dev
 
 secrets-manager: dev/ggzz-server
 
 ---
 
-spring.config.activate.on-profile: local
 spring:
+  config:
+    activate:
+      on-profile: local
   jpa:
     open-in-view: false
     generate-ddl: true
     hibernate:
       ddl-auto: update
-  servlet:
-    multipart:
-      max-file-size: 2MB
-      max-request-size: 20MB
-  jackson:
-    property-naming-strategy: SNAKE_CASE
   datasource:
     url: jdbc:mysql://localhost:3306/infp_db
     username: infp

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterControllerTest.kt
@@ -102,8 +102,8 @@ internal class LetterControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("id").description("API에 사용되는 편지 ID"),
-                        fieldWithPath("createdAt").description("편지 생성일자"),
-                        fieldWithPath("createdBy").description("편지 생성자 닉네임"),
+                        fieldWithPath("created_at").description("편지 생성일자"),
+                        fieldWithPath("created_by").description("편지 생성자 닉네임"),
                         fieldWithPath("title").description("편지 제목"),
                         fieldWithPath("summary").description("편지 내용"),
                         fieldWithPath("longitude").description("경도"),
@@ -152,8 +152,8 @@ internal class LetterControllerTest {
                     responseFields(
                         fieldWithPath("count").description("내 편지 개수"),
                         fieldWithPath("data[].id").description("API에 사용되는 편지 ID"),
-                        fieldWithPath("data[].createdAt").description("편지 생성일자"),
-                        fieldWithPath("data[].createdBy").description("편지 생성자 닉네임"),
+                        fieldWithPath("data[].created_at").description("편지 생성일자"),
+                        fieldWithPath("data[].created_by").description("편지 생성자 닉네임"),
                         fieldWithPath("data[].title").description("편지 제목"),
                         fieldWithPath("data[].summary").description("편지 내용"),
                         fieldWithPath("data[].longitude").description("경도"),
@@ -209,8 +209,8 @@ internal class LetterControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("id").description("API에 사용되는 편지 ID"),
-                        fieldWithPath("createdAt").description("편지 생성일자"),
-                        fieldWithPath("createdBy").description("편지 생성자 닉네임"),
+                        fieldWithPath("created_at").description("편지 생성일자"),
+                        fieldWithPath("created_by").description("편지 생성자 닉네임"),
                         fieldWithPath("title").description("편지 제목"),
                         fieldWithPath("summary").description("편지 내용"),
                         fieldWithPath("longitude").description("경도"),

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/MyLetterControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/MyLetterControllerTest.kt
@@ -73,8 +73,8 @@ internal class MyLetterControllerTest {
                     responseFields(
                         fieldWithPath("count").description("내 편지 개수"),
                         fieldWithPath("data[].id").description("API에 사용되는 편지 ID"),
-                        fieldWithPath("data[].createdAt").description("편지 생성일자"),
-                        fieldWithPath("data[].createdBy").description("편지 생성자 닉네임"),
+                        fieldWithPath("data[].created_at").description("편지 생성일자"),
+                        fieldWithPath("data[].created_by").description("편지 생성자 닉네임"),
                         fieldWithPath("data[].title").description("편지 제목"),
                         fieldWithPath("data[].summary").description("편지 내용"),
                         fieldWithPath("data[].longitude").description("경도"),


### PR DESCRIPTION
## CI 설정: PR 테스트 자동화

### 한줄 요약

PR 올릴 때 자동으로 테스트가 돌아가게 하여, 모든 리뷰어에게 테스트 결과를 볼 수 있게 CI 설정

### 상세 설명

[38e6de82ec3f0e4ec9bc3c8da3b2be0f9c4265f8]: `application.yaml`에서 프로필 상관없이 적용되어야 하는 부분들을 `local` 프로필에서 분리
[8dd53eb729424083735c8c8bc410a9a53ec69982]: CI 설정
[4fc97453c86f6a6e38b170d712b182a7e8cecdb6]: 기본 profile이 `dev`에서 `local`로 변경됨에 따라 Dockerfile 수정. 기존의 shell form보다 exec form을 권장하기 때문에 변경. 추후 production 설정을 위해서 active profile 인자는 CMD로 변경 ([Ref](https://docs.docker.com/engine/reference/builder/#entrypoint))
