### PR TITLE
[FEATURE] 끄적 좋아요 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,14 @@ dependencies {
 
     // H2
     implementation("com.h2database:h2")
+
+    // Kotest & Mockk
+    testImplementation("io.kotest:kotest-runner-junit5:5.6.2")
+    testImplementation("io.kotest:kotest-assertions-core:5.6.2")
+    testImplementation("io.kotest:kotest-property:5.6.2")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/scripts/sql/V1-like.sql
+++ b/scripts/sql/V1-like.sql
@@ -1,0 +1,14 @@
+alter table letter add column number_of_likes integer not null default 0;
+
+create table likes
+(
+    id          bigint not null auto_increment,
+    created_at  datetime(6),
+    modified_at datetime(6),
+    letter_id   bigint,
+    user_id     bigint,
+    primary key (id)
+) engine = InnoDB;
+
+alter table likes add constraint FKghaq0rb8go73nfy0vdioi5qos foreign key (letter_id) references letter (id);
+alter table likes add constraint FKi2wo4dyk4rok7v4kak8sgkwx0 foreign key (user_id) references user (id);

--- a/src/docs/asciidoc/Letter-API.adoc
+++ b/src/docs/asciidoc/Letter-API.adoc
@@ -30,3 +30,23 @@ operation::deleteLetter/200[snippets='http-request,path-parameters,http-response
 === 편지 이미지나 음성 올리기
 
 operation::putResource/200[snippets='http-request,path-parameters,request-parts,http-response,response-fields']
+
+[[끄적-좋아요하기]]
+=== 끄적 좋아요하기
+
+operation::letter-interaction/like[snippets='http-request,path-parameters,http-response']
+
+[[끄적-좋아요-취소하기]]
+=== 끄적 좋아요 취소하기
+
+operation::letter-interaction/unlike[snippets='http-request,path-parameters,http-response']
+
+=== Error Response
+.끄적이 존재하지 않는 경우
+====
+operation::error/4000[snippets='http-response']
+====
+.이미 좋아요한 끄적에 다시 좋아요 요청을 보내는 경우
+====
+operation::error/9001[snippets='http-response']
+====

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionController.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionController.kt
@@ -1,0 +1,35 @@
+package com.wafflestudio.ggzz.domain.letter.controller
+
+import com.wafflestudio.ggzz.domain.letter.dto.LetterDto
+import com.wafflestudio.ggzz.domain.letter.service.LetterInteractionService
+import com.wafflestudio.ggzz.domain.user.model.CurrentUser
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/letters")
+class LetterInteractionController(
+    private val letterInteractionService: LetterInteractionService
+) {
+
+    @PutMapping("/{letter-id}/like")
+    fun likeLetter(
+        @CurrentUser userId: Long,
+        @PathVariable("letter-id") letterId: Long
+    ): ResponseEntity<LetterDto.Response> {
+        return ResponseEntity.ok(letterInteractionService.likeLetter(userId, letterId))
+    }
+
+    @DeleteMapping("/{letter-id}/like")
+    fun unlikeLetter(
+        @CurrentUser userId: Long,
+        @PathVariable("letter-id") letterId: Long
+    ): ResponseEntity<LetterDto.Response> {
+        return ResponseEntity.ok(letterInteractionService.unlikeLetter(userId, letterId))
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionController.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionController.kt
@@ -6,7 +6,7 @@ import com.wafflestudio.ggzz.domain.user.model.CurrentUser
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -16,7 +16,7 @@ class LetterInteractionController(
     private val letterInteractionService: LetterInteractionService
 ) {
 
-    @PutMapping("/{letter-id}/like")
+    @PostMapping("/{letter-id}/like")
     fun likeLetter(
         @CurrentUser userId: Long,
         @PathVariable("letter-id") letterId: Long

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/exception/LikeAlreadyExistsException.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/exception/LikeAlreadyExistsException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.ggzz.domain.letter.exception
+
+import com.wafflestudio.ggzz.global.common.exception.CustomException.ConflictException
+import com.wafflestudio.ggzz.global.common.exception.ErrorType.Conflict.LIKE_ALREADY_EXISTS
+
+class LikeAlreadyExistsException(userId: Long, letterId: Long): ConflictException(
+    LIKE_ALREADY_EXISTS, "User with id '$userId' already liked Letter with id '$letterId'.")

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Letter.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Letter.kt
@@ -18,6 +18,8 @@ class Letter(
     var text: String?,
     var image: String?,
     var voice: String?,
+
+    var numberOfLikes: Int = 0,
 ): BaseTimeTraceEntity() {
     constructor(user: User, request: CreateRequest) : this(
         user = user,

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Like.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Like.kt
@@ -3,14 +3,15 @@ package com.wafflestudio.ggzz.domain.letter.model
 import com.wafflestudio.ggzz.domain.user.model.User
 import com.wafflestudio.ggzz.global.common.model.BaseTimeTraceEntity
 import jakarta.persistence.Entity
-import jakarta.persistence.OneToOne
+import jakarta.persistence.FetchType
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
 @Table(name = "likes")
 class Like(
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     val user: User,
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     val letter: Letter,
 ): BaseTimeTraceEntity()

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Like.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/model/Like.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.ggzz.domain.letter.model
+
+import com.wafflestudio.ggzz.domain.user.model.User
+import com.wafflestudio.ggzz.global.common.model.BaseTimeTraceEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "likes")
+class Like(
+    @OneToOne
+    val user: User,
+    @OneToOne
+    val letter: Letter,
+): BaseTimeTraceEntity()

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/repository/LikeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/repository/LikeRepository.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.ggzz.domain.letter.repository;
+
+import com.wafflestudio.ggzz.domain.letter.model.Like
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LikeRepository : JpaRepository<Like, Long> {
+    fun findLikeByUserIdAndLetterId(userId: Long, letterId: Long): Like?
+}

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/service/LetterInteractionService.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/letter/service/LetterInteractionService.kt
@@ -1,0 +1,48 @@
+package com.wafflestudio.ggzz.domain.letter.service
+
+import com.wafflestudio.ggzz.domain.letter.dto.LetterDto
+import com.wafflestudio.ggzz.domain.letter.exception.LetterNotFoundException
+import com.wafflestudio.ggzz.domain.letter.exception.LikeAlreadyExistsException
+import com.wafflestudio.ggzz.domain.letter.model.Like
+import com.wafflestudio.ggzz.domain.letter.repository.LetterRepository
+import com.wafflestudio.ggzz.domain.letter.repository.LikeRepository
+import com.wafflestudio.ggzz.domain.user.exception.UserNotFoundException
+import com.wafflestudio.ggzz.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class LetterInteractionService(
+    private val userRepository: UserRepository,
+    private val letterRepository: LetterRepository,
+    private val likeRepository: LikeRepository
+) {
+    @Transactional
+    fun likeLetter(userId: Long, letterId: Long): LetterDto.Response {
+        val user = userRepository.findUserById(userId) ?: throw UserNotFoundException(userId)
+        val letter = letterRepository.findLetterById(letterId) ?: throw LetterNotFoundException(letterId)
+
+        likeRepository.findLikeByUserIdAndLetterId(userId, letterId)?.let {
+            throw LikeAlreadyExistsException(userId, letterId)
+        }
+
+        likeRepository.save(Like(user, letter))
+        letter.numberOfLikes += 1
+
+        return LetterDto.Response(letter)
+    }
+
+    @Transactional
+    fun unlikeLetter(userId: Long, letterId: Long): LetterDto.Response {
+        userRepository.findUserById(userId) ?: throw UserNotFoundException(userId)
+        val letter = letterRepository.findLetterById(letterId) ?: throw LetterNotFoundException(letterId)
+
+        likeRepository.findLikeByUserIdAndLetterId(userId, letterId)?.let {
+            likeRepository.delete(it)
+            letter.numberOfLikes -= 1
+        }
+
+        return LetterDto.Response(letter)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/user/exception/UserNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.ggzz.domain.user.exception
+
+import com.wafflestudio.ggzz.global.common.exception.CustomException
+import com.wafflestudio.ggzz.global.common.exception.ErrorType.NotFound.USER_NOT_FOUND
+
+class UserNotFoundException(id: Long): CustomException.NotFoundException(USER_NOT_FOUND, "User with id '$id' does not exists.")

--- a/src/main/kotlin/com/wafflestudio/ggzz/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/domain/user/repository/UserRepository.kt
@@ -7,4 +7,5 @@ interface UserRepository : JpaRepository<User, Long> {
     fun findMeById(id: Long): User
     fun existsByUsername(username: String): Boolean
     fun findByUsername(username: String): User?
+    fun findUserById(id: Long): User?
 }

--- a/src/main/kotlin/com/wafflestudio/ggzz/global/common/exception/ErrorType.kt
+++ b/src/main/kotlin/com/wafflestudio/ggzz/global/common/exception/ErrorType.kt
@@ -34,6 +34,7 @@ enum class ErrorType {
 
     enum class NotFound(private val code: Int): ErrorTypeInterface {
         LETTER_NOT_FOUND(4000),
+        USER_NOT_FOUND(4001),
         ;
 
         override fun getCode(): Int = code
@@ -41,6 +42,7 @@ enum class ErrorType {
 
     enum class Conflict(private val code: Int): ErrorTypeInterface {
         USERNAME_CONFLICT(9000),
+        LIKE_ALREADY_EXISTS(9001),
         ;
         override fun getCode(): Int = code
     }

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/ApiDocumentUtils.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/ApiDocumentUtils.kt
@@ -1,18 +1,30 @@
 package com.wafflestudio.ggzz.domain
 
-import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor
-import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor
 import org.springframework.restdocs.operation.preprocess.Preprocessors.*
+import java.util.regex.Pattern
 
 interface ApiDocumentUtils {
 
     companion object {
-        fun getDocumentRequest(): OperationRequestPreprocessor {
-            return preprocessRequest(prettyPrint())
-        }
+        fun getDocumentRequest() = preprocessRequest(
+            modifyUris()
+                .scheme("https")
+                .host("ggzz-dev-api.wafflestudio.com")
+                .removePort(),
+            replacePattern(Pattern.compile("_csrf=.*\$"), ""),
+            prettyPrint()
+        )!!
 
-        fun getDocumentResponse(): OperationResponsePreprocessor {
-            return preprocessResponse(prettyPrint())
-        }
+        fun getDocumentResponse() = preprocessResponse(
+            modifyHeaders()
+                .removeMatching("Vary")
+                .removeMatching("X-Content-Type-Options")
+                .removeMatching("X-XSS-Protection")
+                .removeMatching("Cache-Control")
+                .removeMatching("Pragma")
+                .removeMatching("Expires")
+                .removeMatching("X-Frame-Options"),
+            prettyPrint()
+        )!!
     }
 }

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/global/common/exception/ExceptionDescribeSpec.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/global/common/exception/ExceptionDescribeSpec.kt
@@ -1,0 +1,123 @@
+package com.wafflestudio.ggzz.domain.global.common.exception
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.ggzz.domain.ApiDocumentUtils.Companion.getDocumentResponse
+import com.wafflestudio.ggzz.domain.global.common.exception.ExceptionDescribeSpec.ExceptionTestConfig.ExceptionTestController
+import com.wafflestudio.ggzz.domain.global.common.exception.ExceptionDescribeSpec.ExceptionTestConfig.ExceptionTestService
+import com.wafflestudio.ggzz.domain.letter.exception.LetterNotFoundException
+import com.wafflestudio.ggzz.domain.letter.exception.LikeAlreadyExistsException
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import org.hamcrest.core.Is.`is`
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.http.ResponseEntity
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.stereotype.Service
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@WebMvcTest(ExceptionTestController::class, excludeAutoConfiguration = [SecurityAutoConfiguration::class])
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@DisplayName("Exception Rest Docs")
+class ExceptionDescribeSpec(
+    private val mockMvc: MockMvc,
+    @MockkBean private val exceptionTestService: ExceptionTestService
+): DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @TestConfiguration
+    class ExceptionTestConfig {
+        @Service
+        class ExceptionTestService {
+            fun error() {}
+        }
+
+        @Validated
+        @RestController
+        @RequestMapping("/error")
+        class ExceptionTestController(private val exceptionTestService: ExceptionTestService) {
+            @GetMapping("/{id}")
+            fun constraintViolation(@PathVariable("id") @Positive id: Long): ResponseEntity<Any> {
+                return ResponseEntity.ok().build()
+            }
+
+            @GetMapping
+            fun serviceError(): ResponseEntity<Any> {
+                exceptionTestService.error()
+                return ResponseEntity.ok().build()
+            }
+
+            @PostMapping
+            fun invalidField(@RequestBody @Valid request: ExceptionTestDto): ResponseEntity<Any> {
+                return ResponseEntity.ok().build()
+            }
+
+            @GetMapping("/params")
+            fun parameterTypeMismatch(@RequestParam int: Int): ResponseEntity<Any> {
+                return ResponseEntity.ok().build()
+            }
+        }
+
+        data class ExceptionTestDto(
+            @field:[NotBlank]
+            private val notBlankField: String?,
+            @field:[NotNull Positive]
+            private val nonNullablePositiveField: Int,
+            @field:[Positive]
+            private val nullablePositiveField: Int?,
+            private val enumField: ExceptionEnum?
+        )
+
+        enum class ExceptionEnum {
+            @JsonProperty("PROPER")
+            PROPER
+        }
+    }
+
+    init {
+        this.describe("Letter 도메인") {
+            context("끄적이 존재하지 않는 경우") {
+                every { exceptionTestService.error() } throws LetterNotFoundException(1L)
+
+                it("LETTER_NOT_FOUND: 에러코드 4000") {
+                    mockMvc.perform(get("/error"))
+                        .andDo(document(
+                            "error/4000",
+                            getDocumentResponse()))
+                        .andExpect(status().isNotFound)
+                        .andExpect(jsonPath("$.error_code", `is`(4000)))
+                }
+            }
+
+            context("좋아요한 끄적에 다시 좋아요한 경우") {
+                every { exceptionTestService.error() } throws LikeAlreadyExistsException(1L, 1L)
+
+                it("LIKE_ALREADY_EXISTS: 에러코드 9001") {
+                    mockMvc.perform(get("/error"))
+                        .andDo(document(
+                            "error/9001",
+                            getDocumentResponse()))
+                        .andExpect(status().isConflict)
+                        .andExpect(jsonPath("$.error_code", `is`(9001)))
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionRestDocsTest.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionRestDocsTest.kt
@@ -1,0 +1,94 @@
+package com.wafflestudio.ggzz.domain.letter.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import com.wafflestudio.ggzz.domain.ApiDocumentUtils.Companion.getDocumentRequest
+import com.wafflestudio.ggzz.domain.ApiDocumentUtils.Companion.getDocumentResponse
+import com.wafflestudio.ggzz.domain.letter.dto.LetterDto
+import com.wafflestudio.ggzz.domain.letter.model.Letter
+import com.wafflestudio.ggzz.domain.letter.service.LetterInteractionService
+import com.wafflestudio.ggzz.domain.user.model.User
+import com.wafflestudio.ggzz.domain.user.model.UserPrincipal
+import com.wafflestudio.ggzz.domain.user.model.UserToken
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(LetterInteractionController::class)
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@MockkBean(JpaMetamodelMappingContext::class)
+@DisplayName("LetterInteractionController Rest Docs")
+class LetterInteractionRestDocsTest(
+    private val mockMvc: MockMvc,
+    @MockkBean private val letterInteractionService: LetterInteractionService
+): DescribeSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        private val user = User("username", "nickname", "password")
+        private val letter = Letter(user, "title", "summary", 0.0, 0.0, "text", "image", "voice")
+        private val auth = UserToken(UserPrincipal(user))
+    }
+
+    override suspend fun beforeContainer(testCase: TestCase) {
+        every { letterInteractionService.likeLetter(any(), any()) } returns LetterDto.Response(letter)
+        every { letterInteractionService.unlikeLetter(any(), any()) } returns LetterDto.Response(letter)
+    }
+
+    init {
+        this.describe("좋아요 API") {
+            context("정상적인 호출인 경우") {
+                it("200 OK: LetterDto.Response") {
+                    letter.numberOfLikes = 1
+
+                    mockMvc.perform(
+                        put("/api/v1/letters/{letter-id}/like", 1L)
+                            .with(authentication(auth)).with(csrf())
+                    ).andDo(document(
+                        "letter-interaction/like",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("letter-id").description("좋아요할 편지의 ID")))
+                    ).andDo(print()
+                    ).andExpect(status().isOk())
+                }
+            }
+        }
+
+        this.describe("좋아요 취소 API") {
+            context("정상적인 호출인 경우") {
+                it("200 OK: LetterDto.Response") {
+                    letter.numberOfLikes = 0
+
+                    mockMvc.perform(
+                        delete("/api/v1/letters/{letter-id}/like", 1L)
+                            .with(authentication(auth)).with(csrf())
+                    ).andDo(document(
+                        "letter-interaction/unlike",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(parameterWithName("letter-id").description("좋아요 취소할 편지의 ID")))
+                    ).andDo(print()
+                    ).andExpect(status().isOk())
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionRestDocsTest.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/controller/LetterInteractionRestDocsTest.kt
@@ -19,8 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
@@ -58,7 +57,7 @@ class LetterInteractionRestDocsTest(
                     letter.numberOfLikes = 1
 
                     mockMvc.perform(
-                        put("/api/v1/letters/{letter-id}/like", 1L)
+                        post("/api/v1/letters/{letter-id}/like", 1L)
                             .with(authentication(auth)).with(csrf())
                     ).andDo(document(
                         "letter-interaction/like",

--- a/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/service/LetterInteractionServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/ggzz/domain/letter/service/LetterInteractionServiceTest.kt
@@ -1,0 +1,152 @@
+package com.wafflestudio.ggzz.domain.letter.service
+
+import com.wafflestudio.ggzz.domain.letter.exception.LetterNotFoundException
+import com.wafflestudio.ggzz.domain.letter.exception.LikeAlreadyExistsException
+import com.wafflestudio.ggzz.domain.letter.model.Letter
+import com.wafflestudio.ggzz.domain.letter.model.Like
+import com.wafflestudio.ggzz.domain.letter.repository.LetterRepository
+import com.wafflestudio.ggzz.domain.letter.repository.LikeRepository
+import com.wafflestudio.ggzz.domain.user.exception.UserNotFoundException
+import com.wafflestudio.ggzz.domain.user.model.User
+import com.wafflestudio.ggzz.domain.user.repository.UserRepository
+import com.wafflestudio.ggzz.global.common.exception.ErrorType.Conflict.LIKE_ALREADY_EXISTS
+import com.wafflestudio.ggzz.global.common.exception.ErrorType.NotFound.LETTER_NOT_FOUND
+import com.wafflestudio.ggzz.global.common.exception.ErrorType.NotFound.USER_NOT_FOUND
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+
+@DisplayName("LetterInteractionService 테스트")
+class LetterInteractionServiceTest : BehaviorSpec() {
+
+    companion object {
+        private val userRepository = mockk<UserRepository>()
+        private val letterRepository = mockk<LetterRepository>()
+        private val likeRepository = mockk<LikeRepository>()
+        private val letterInteractionService = LetterInteractionService(userRepository, letterRepository, likeRepository)
+
+        private const val USER_ID = 1L
+        private const val NON_EXISTING_USER_ID = 2L
+
+        private const val LETTER_ID = 1L
+        private const val NON_EXISTING_LETTER_ID = 2L
+        private const val ALREADY_LIKED_LETTER_ID = 3L
+
+        private val user = User("username", "nickname", "password")
+        private val letter = Letter(user, "title", "summary", 0.0, 0.0, "text", "image", "voice")
+        private val likedLetter = Letter(user, "title", "summary", 0.0, 0.0, "text", "image", "voice", 1)
+        private val like = Like(user, letter)
+
+        private val likeSlot = slot<Like>()
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        every { userRepository.findUserById(USER_ID) } returns user
+        every { userRepository.findUserById(NON_EXISTING_USER_ID) } returns null
+
+        every { letterRepository.findLetterById(LETTER_ID) } returns letter
+        every { letterRepository.findLetterById(NON_EXISTING_LETTER_ID) } returns null
+        every { letterRepository.findLetterById(ALREADY_LIKED_LETTER_ID) } returns likedLetter
+
+        every { likeRepository.findLikeByUserIdAndLetterId(USER_ID, LETTER_ID) } returns null
+        every { likeRepository.findLikeByUserIdAndLetterId(USER_ID, ALREADY_LIKED_LETTER_ID) } returns like
+
+        every { likeRepository.save(capture(likeSlot)) } answers { likeSlot.captured }
+
+        justRun { likeRepository.delete(any()) }
+    }
+
+    init {
+        this.Given("존재하지 않는 유저 ID로") {
+            When("좋아요를 누르면") {
+                Then("UserNotFoundException이 발생한다") {
+                    val exception = shouldThrow<UserNotFoundException> {
+                        letterInteractionService.likeLetter(NON_EXISTING_USER_ID, LETTER_ID)
+                    }
+                    exception.errorType shouldBe USER_NOT_FOUND
+                }
+            }
+
+            When("좋아요를 취소하면") {
+                Then("UserNotFoundException이 발생한다") {
+                    val exception = shouldThrow<UserNotFoundException> {
+                        letterInteractionService.unlikeLetter(NON_EXISTING_USER_ID, LETTER_ID)
+                    }
+                    exception.errorType shouldBe USER_NOT_FOUND
+                }
+            }
+        }
+
+        this.Given("존재하지 않는 끄적 ID로") {
+            When("좋아요를 누르면") {
+                Then("LetterNotFoundException이 발생한다") {
+                    val exception = shouldThrow<LetterNotFoundException> {
+                        letterInteractionService.likeLetter(USER_ID, NON_EXISTING_LETTER_ID)
+                    }
+                    exception.errorType shouldBe LETTER_NOT_FOUND
+                }
+            }
+
+            When("좋아요를 취소하면") {
+                Then("LetterNotFoundException이 발생한다") {
+                    val exception = shouldThrow<LetterNotFoundException> {
+                        letterInteractionService.unlikeLetter(USER_ID, NON_EXISTING_LETTER_ID)
+                    }
+                    exception.errorType shouldBe LETTER_NOT_FOUND
+                }
+            }
+        }
+
+        this.Given("이미 좋아요를 누른 끄적에 대해") {
+            When("좋아요를 누르면") {
+                Then("LikeAlreadyExistsException이 발생한다") {
+                    val exception = shouldThrow<LikeAlreadyExistsException> {
+                        letterInteractionService.likeLetter(USER_ID, ALREADY_LIKED_LETTER_ID)
+                    }
+                    exception.errorType shouldBe LIKE_ALREADY_EXISTS
+                }
+            }
+
+            When("좋아요를 취소하면") {
+                Then("Like 개수가 떨어진다") {
+                    val beforeNumberOfLikes = likedLetter.numberOfLikes
+                    letterInteractionService.unlikeLetter(USER_ID, ALREADY_LIKED_LETTER_ID)
+
+                    likedLetter.numberOfLikes shouldBe beforeNumberOfLikes - 1
+                }
+            }
+        }
+
+        this.Given("좋아요를 누르지 않은 끄적에 대해") {
+            When("좋아요를 누르면") {
+                Then("Like 개수가 늘어난다") {
+                    val beforeNumberOfLikes = letter.numberOfLikes
+                    letterInteractionService.likeLetter(USER_ID, LETTER_ID)
+
+                    letter.numberOfLikes shouldBe beforeNumberOfLikes + 1
+                }
+            }
+
+            When("좋아요를 취소하면") {
+                Then("아무 일도 일어나지 않는다") {
+                    val beforeNumberOfLikes = letter.numberOfLikes
+                    letterInteractionService.unlikeLetter(USER_ID, LETTER_ID)
+
+                    letter.numberOfLikes shouldBe beforeNumberOfLikes
+                }
+            }
+        }
+
+        this.Given("자기 끄적에 대해") {
+            When("좋아요를 눌러도") {
+                Then("예외가 발생하지 않는다") {
+                    shouldNotThrowAny { letterInteractionService.likeLetter(USER_ID, LETTER_ID) }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 제목

끄적 좋아요 API

### 한줄 요약

끄적에 좋아요, 좋아요 취소할 수 있는 API 개발
`POST /api/v1/letters/{letter-id}/like`
`DELETE /api/v1/letters/{letter-id}/like`

### 상세 설명

[d84f0b150149162819ac14e9fea98b15c31cc49e]: Letter 엔티티에 `number_of_likes` 필드 추가, Like 엔티티 추가
[b50eac5bdef436ef7c4f959554bb8c592579d085]: 서비스 로직에 사용될 예외 추가
[5e06f9673155c764b6c2664f0bb8440b25a3cb8f]: Controller, Service, Repository 수정 및 개발
[4c1ccbc0c4f929484e394f07e46452b8c24f3da7]: 테스트에 사용될 의존성 추가
[c317742e5bf394da2beef1523a2a8e725b4035f1]: 서비스 테스트
[0cec1a69dc0b3f6702f490a2958519b7f55143af]: API 문서 작성을 위한 테스트
[55fd68961867057839a8edab6794993db994977f]: 개발 DB에 날릴 쿼리 (merge 되기 전에 제가 날리겠습니다)
[fad99591e12348289a52b5bdc29012dc69d10952]: 좋아요 API HTTP 메소드 수정

### 설계 고민들
- Letter 엔티티에 `number_of_likes` 추가
  - 해당 필드를 추가함으로써 테이블의 정규화가 깨지지만, 끄적 조회시 count 쿼리를 날릴 필요가 없다는 장점이 있어서 이렇게 설계했습니다.
  - 데이터 정합성이 조금 우려되지만, 동시성 테스트를 해보면 좋을 것 같네요.
- 자기 끄적에 대한 좋아요 허용
  - 좋아요 하나 더 늘어난다고 해서 상관 없을 것 같아서 일단 허용해두었습니다.
- 좋아요 API의 HTTP 메소드
  - 처음엔 PUT으로 했으나, 중복된 요청에 대해 예외를 발생시키므로 Idempotent하지 않아서 POST로 수정하였습니다.
- API 문서 작성
  - BDD 스타일의 Rest-Assured Rest Docs가 아닌 Mock MVC 기반의 Rest Docs 이기에,
  굳이 예외를 발생시키는 데이터를 넣어서 스니펫을 만들기보다는
  가상의 Service Layer가 예외를 발생시키도록 Mocking하는 것이 좋지 않을까 해서
  `src/test/.../global/common/exception/ExceptionDescribeSpec.kt`에 Error Response를 만드는 테스트를 작성했습니다.

### TODO

- `like` 테이블에 (`user_id`, `letter_id`) multi-column index 도입 고려해보기 (이에 대한 의견도 남겨주시면 좋겠습니다)
- Letter의 `number_of_likes` 동시성 테스트
